### PR TITLE
Persistent component state

### DIFF
--- a/src/common/collapsible/Collapsible.tsx
+++ b/src/common/collapsible/Collapsible.tsx
@@ -1,14 +1,16 @@
 import React, { HTMLProps, useCallback } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import styles from './Collapsible.module.scss';
+import useSessionStorageState from '../../hooks/useSessionStorageState';
 
 type Props = {
+  id: string;
   expand: boolean;
   onCollapse: () => void;
 } & HTMLProps<HTMLDivElement>;
 
-const Collapsible: React.FunctionComponent<Props> = ({ expand, children, onCollapse, ...rest }) => {
-  const [height, setHeight] = useState(0);
+const Collapsible: React.FunctionComponent<Props> = ({ id, expand, children, onCollapse, ...rest }) => {
+  const [height, setHeight] = useSessionStorageState({ defaultValue: 0, key: `collapsible-${id}` });
 
   const ref = useRef<HTMLDivElement>(null);
   let timer = useRef<NodeJS.Timeout | null>(null);
@@ -20,7 +22,7 @@ const Collapsible: React.FunctionComponent<Props> = ({ expand, children, onColla
     } else {
       setHeight(0);
     }
-  }, [expand]);
+  }, [expand, setHeight]);
 
   /**
    * Debounce to prevent too much re-rendering

--- a/src/common/infoblock/InfoBlock.tsx
+++ b/src/common/infoblock/InfoBlock.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { IconAngleRight, IconCross } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 import { DataConfig } from '../../types/common';
+import useSessionStorageState from '../../hooks/useSessionStorageState';
 
 import css from './InfoBlock.module.scss';
 
@@ -13,7 +14,7 @@ type Props = {
 
 const InfoBlock = ({ config }: Props) => {
   const [width, setWidth] = useState(window.innerWidth);
-  const [isHidden, setHidden] = React.useState(sessionStorage.getItem('infoBlockHidden') || 'false');
+  const [isHidden, setHidden] = useSessionStorageState({ defaultValue: false, key: 'infoBlockHidden' });
   const [isMinified, setIsMinified] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const infoBlockRef = useRef<HTMLDivElement>(null);
@@ -45,12 +46,8 @@ const InfoBlock = ({ config }: Props) => {
     };
   }, []);
 
-  useEffect(() => {
-    sessionStorage.setItem('infoBlockHidden', isHidden);
-  }, [isHidden]);
-
   const hideInfoBlock = () => {
-    setHidden('true');
+    setHidden(true);
 
     if (infoBlockRef.current) {
       infoBlockRef.current.focus();
@@ -119,7 +116,7 @@ const InfoBlock = ({ config }: Props) => {
     );
   }
 
-  if (isHidden !== null && JSON.parse(isHidden)) {
+  if (isHidden) {
     return <div ref={infoBlockRef} tabIndex={-1} />;
   }
 

--- a/src/hooks/useSessionStorageState.ts
+++ b/src/hooks/useSessionStorageState.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+type Props = {
+  defaultValue: any;
+  key: string;
+};
+
+const useSessionStorageState = ({ defaultValue, key }: Props) => {
+  const [value, setValue] = useState(() => {
+    const storageValue = sessionStorage.getItem(key);
+    return storageValue !== null && storageValue !== undefined ? JSON.parse(storageValue) : defaultValue;
+  });
+
+  useEffect(() => {
+    if (value === undefined) {
+      sessionStorage.removeItem(key);
+    } else {
+      sessionStorage.setItem(key, JSON.stringify(value));
+    }
+  }, [key, value]);
+
+  return [value, setValue];
+};
+
+export default useSessionStorageState;

--- a/src/modules/search/SearchContainer.tsx
+++ b/src/modules/search/SearchContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import SearchResults from './components/result/list/SearchResults';
@@ -12,6 +12,7 @@ import { groupProjectsByState } from './utils/groupProjectsByState';
 import useSearchParams from '../../hooks/useSearchParams';
 import { DataContext } from './DataContext';
 import { filterProjectsByOwnershipType } from './utils/filterProjectsByOwnershipType';
+import useSessionStorageState from '../../hooks/useSessionStorageState';
 
 // "boolean" as a string because env variables are also treated as strings
 const showUpcomingOnly = process.env.REACT_APP_SHOW_UPCOMING_ONLY || 'false';
@@ -20,7 +21,7 @@ const showUpcomingOnly = process.env.REACT_APP_SHOW_UPCOMING_ONLY || 'false';
 const projectOwnershipType = process.env.REACT_APP_PROJECT_OWNERSHIP_TYPE || 'hitas';
 
 const SearchContainer = () => {
-  const [showMap, setShowMap] = useState<boolean>(false);
+  const [showMap, setShowMap] = useSessionStorageState({ defaultValue: false, key: 'showMap' });
   const mapFocusRef = useRef<HTMLDivElement>(null);
   const { t, i18n } = useTranslation();
 

--- a/src/modules/search/components/form/SearchForm.tsx
+++ b/src/modules/search/components/form/SearchForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styles from './SearchForm.module.scss';
 import { Button, IconSearch, IconMinus, IconPlus, IconCross } from 'hds-react';
 import cx from 'classnames';
@@ -9,6 +9,7 @@ import { DataConfig, FilterName, FilterConfigs } from '../../../../types/common'
 import TagList from './tag/TagList';
 import { useTranslation } from 'react-i18next';
 import useFilters from '../../../../hooks/useFilters';
+import useSessionStorageState from '../../../../hooks/useSessionStorageState';
 
 type Props = {
   config: DataConfig | undefined;
@@ -20,8 +21,11 @@ type Props = {
 
 const SearchForm = ({ config, isLoading, isError, pageTitle, onSubmit }: Props) => {
   const { clearAllFilters, hasFilters } = useFilters();
-  const [isOptionsOpen, setOptionsOpen] = useState(false);
-  const [isOptionsVisible, setOptionsVisible] = useState(false);
+  const [isOptionsOpen, setOptionsOpen] = useSessionStorageState({ defaultValue: false, key: 'searchFormOptionsOpen' });
+  const [isOptionsVisible, setOptionsVisible] = useSessionStorageState({
+    defaultValue: false,
+    key: 'searchFormOptionsVisible',
+  });
   const { t } = useTranslation();
   const { filters } = config || {};
   const { project_district, room_count, living_area, debt_free_sales_price, ...additionalFilters } = filters || {};
@@ -70,6 +74,7 @@ const SearchForm = ({ config, isLoading, isError, pageTitle, onSubmit }: Props) 
           </div>
         </div>
         <Collapsible
+          id={'optionsCollapse'}
           expand={isOptionsOpen}
           onCollapse={() => {
             setOptionsVisible(false);

--- a/src/modules/search/components/result/list/ApartmentRow.tsx
+++ b/src/modules/search/components/result/list/ApartmentRow.tsx
@@ -6,6 +6,7 @@ import { IconAngleDown, IconAngleUp, IconPenLine } from 'hds-react';
 import { Apartment } from '../../../../../types/common';
 import { fullURL } from '../../../utils/fullURL';
 import RenderAvailabilityInfo from '../ApplicationStatus';
+import useSessionStorageState from '../../../../../hooks/useSessionStorageState';
 
 import css from './ApartmentRow.module.scss';
 
@@ -18,9 +19,24 @@ type Props = {
 };
 
 const ApartmentRow = ({ apartment, userApplications, applicationStatus }: Props) => {
+  const {
+    apartment_number,
+    apartment_state_of_sale,
+    apartment_structure,
+    application_url,
+    floor,
+    floor_max,
+    nid,
+    project_application_start_time,
+    project_application_end_time,
+    living_area,
+    debt_free_sales_price,
+    url,
+  } = apartment;
+
   const { t } = useTranslation();
   const [width, setWidth] = useState(window.innerWidth);
-  const [rowOpen, setRowOpen] = useState(false);
+  const [rowOpen, setRowOpen] = useSessionStorageState({ defaultValue: false, key: `apartmentRowOpen-${nid}` });
 
   const isDesktopSize = width > BREAK_POINT;
   const isMobileSize = width <= BREAK_POINT;
@@ -40,21 +56,6 @@ const ApartmentRow = ({ apartment, userApplications, applicationStatus }: Props)
 
     return () => window.removeEventListener('resize', handleResize);
   }, []);
-
-  const {
-    apartment_number,
-    apartment_state_of_sale,
-    apartment_structure,
-    application_url,
-    floor,
-    floor_max,
-    nid,
-    project_application_start_time,
-    project_application_end_time,
-    living_area,
-    debt_free_sales_price,
-    url,
-  } = apartment;
 
   const hasApplication = () => {
     if (!userApplications) {

--- a/src/modules/search/components/result/list/ApartmentTable.tsx
+++ b/src/modules/search/components/result/list/ApartmentTable.tsx
@@ -1,12 +1,14 @@
-import React, { useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import cx from 'classnames';
 import { IconAngleLeft, IconAngleRight, IconSortAscending, IconSortDescending } from 'hds-react';
 import { useTranslation } from 'react-i18next';
 
-import { Apartment, ApartmentApplicationStatusConfig } from '../../../../../types/common';
+import { Apartment, ApartmentApplicationStatusConfig, Project } from '../../../../../types/common';
 import { getApartmentApplicationStatus } from '../../../utils/getApplicationStatus';
 import SortApartments from '../../../utils/sortApartments';
 import ApartmentRow from './ApartmentRow';
+import useSessionStorageState from '../../../../../hooks/useSessionStorageState';
+
 import css from './ApartmentTable.module.scss';
 
 type Props = {
@@ -14,13 +16,14 @@ type Props = {
   applications: number[] | undefined;
   applicationStatus: ApartmentApplicationStatusConfig | undefined;
   housingCompany: string | undefined;
+  projectID: Project['id'];
 };
 
-const ApartmentTable = ({ apartments, applications, applicationStatus, housingCompany }: Props) => {
+const ApartmentTable = ({ apartments, applications, applicationStatus, housingCompany, projectID }: Props) => {
   const { t } = useTranslation();
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useSessionStorageState({ defaultValue: 1, key: `apartmentTablePaginationPage-${projectID}` });
   const paginationScrollRef = useRef<HTMLDivElement>(null);
-  const { items, requestSort, sortConfig } = SortApartments(apartments);
+  const { items, requestSort, sortConfig } = SortApartments(apartments, `project-${projectID}`);
   const displayedApartments = items.slice(page * 10 - 10, page * 10);
 
   const setSort = (key: string, alphaNumeric: boolean) => {

--- a/src/modules/search/components/result/list/ProjectCard.tsx
+++ b/src/modules/search/components/result/list/ProjectCard.tsx
@@ -13,6 +13,8 @@ import useModal from '../../../../../hooks/useModal';
 import SubscriptionForm from '../SubscriptionForm';
 import ProjectInfo from '../ProjectInfo';
 import Label from '../../../../../common/label/Label';
+import useSessionStorageState from '../../../../../hooks/useSessionStorageState';
+
 import css from './ProjectCard.module.scss';
 import 'pure-react-carousel/dist/react-carousel.es.css';
 
@@ -33,8 +35,20 @@ const ProjectCard = ({
   currentLang,
   hideApartments = false,
 }: Props) => {
+  const {
+    apartments,
+    street_address,
+    district,
+    housing_company,
+    image_urls,
+    main_image_url,
+    id,
+    ownership_type,
+    url,
+  } = project;
+
   const { t } = useTranslation();
-  const [listOpen, setListOpen] = useState(false);
+  const [listOpen, setListOpen] = useSessionStorageState({ defaultValue: false, key: `apartmentRowOpen-${id}` });
   const { openModal, closeModal, Modal } = useModal();
   const [width, setWidth] = useState(window.innerWidth);
 
@@ -55,18 +69,6 @@ const ProjectCard = ({
   };
 
   const { apartment_application_status, user } = config || {};
-
-  const {
-    apartments,
-    street_address,
-    district,
-    housing_company,
-    image_urls,
-    main_image_url,
-    id,
-    ownership_type,
-    url,
-  } = project;
 
   const filteredApartments = getLanguageFilteredApartments(apartments, currentLang);
   const hasApartments = !!filteredApartments.length;
@@ -200,6 +202,7 @@ const ProjectCard = ({
               applications={getUserApplications(user, id)}
               applicationStatus={getProjectApplicationStatus(apartment_application_status, id)}
               housingCompany={housing_company}
+              projectID={id}
             />
           )}
         </div>

--- a/src/modules/search/components/result/map/MapApartmentRow.tsx
+++ b/src/modules/search/components/result/map/MapApartmentRow.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { IconAngleDown, IconAngleUp, IconPenLine } from 'hds-react';
 
 import { Apartment } from '../../../../../types/common';
 import { fullURL } from '../../../utils/fullURL';
 import RenderAvailabilityInfo from '../ApplicationStatus';
+import useSessionStorageState from '../../../../../hooks/useSessionStorageState';
 
 import css from './MapApartmentRow.module.scss';
 
@@ -16,17 +17,6 @@ type Props = {
 };
 
 const MapApartmentRow = ({ apartment, userApplications, applicationStatus, isMobileSize }: Props) => {
-  const { t } = useTranslation();
-  const [rowOpen, setRowOpen] = useState(false);
-
-  const isDesktopSize = !isMobileSize;
-
-  const toggleRow = () => {
-    if (isMobileSize) {
-      setRowOpen(!rowOpen);
-    }
-  };
-
   const {
     apartment_number,
     apartment_state_of_sale,
@@ -41,6 +31,17 @@ const MapApartmentRow = ({ apartment, userApplications, applicationStatus, isMob
     debt_free_sales_price,
     url,
   } = apartment;
+
+  const { t } = useTranslation();
+  const [rowOpen, setRowOpen] = useSessionStorageState({ defaultValue: false, key: `MapApartmentRowOpen-${nid}` });
+
+  const isDesktopSize = !isMobileSize;
+
+  const toggleRow = () => {
+    if (isMobileSize) {
+      setRowOpen(!rowOpen);
+    }
+  };
 
   const hasApplication = () => {
     if (!userApplications) {

--- a/src/modules/search/components/result/map/MapProjectCard.tsx
+++ b/src/modules/search/components/result/map/MapProjectCard.tsx
@@ -52,7 +52,7 @@ const MapProjectCard = ({ config, project, currentLang }: Props) => {
   const { apartment_application_status, user } = config || {};
 
   const { apartments, street_address, district, housing_company, main_image_url, id, ownership_type, url } = project;
-  const { items } = SortApartments(apartments);
+  const { items } = SortApartments(apartments, `mapProject-${id}`);
 
   const filteredApartments = getLanguageFilteredApartments(items, currentLang);
   const hasApartments = !!filteredApartments.length;

--- a/src/modules/search/components/result/map/MapResults.tsx
+++ b/src/modules/search/components/result/map/MapResults.tsx
@@ -1,13 +1,16 @@
-import React, { createRef, useRef, useState } from 'react';
+import React, { createRef, useRef } from 'react';
 import ReactDOMServer from 'react-dom/server';
 import { useTranslation } from 'react-i18next';
 import { MapContainer, Marker, Popup, TileLayer, ZoomControl } from 'react-leaflet';
 import { Button, IconCross, IconLocation, IconMenuHamburger } from 'hds-react';
 import L from 'leaflet';
+
 import { DataConfig, Project, StateOfSale } from '../../../../../types/common';
 import { calculateApartmentCount } from '../../../utils/calculateApartmentCount';
 import MapProjectCard from './MapProjectCard';
 import MapProjectPopupCard from './MapProjectPopupCard';
+import useSessionStorageState from '../../../../../hooks/useSessionStorageState';
+
 import css from './MapResults.module.scss';
 
 type Props = {
@@ -33,7 +36,10 @@ const MapResults = ({
   hideApartments = false,
 }: Props) => {
   const { t } = useTranslation();
-  const [activeProject, setActiveProject] = useState<Project | undefined>(undefined);
+  const [activeProject, setActiveProject] = useSessionStorageState({
+    defaultValue: null,
+    key: 'MapResultsActiveProject',
+  });
   const popupRef = useRef<any>([]);
   const activeProjectRef = useRef<HTMLDivElement>(null);
   popupRef.current = searchResults.map((element, i) => popupRef.current[i] ?? createRef());
@@ -54,7 +60,7 @@ const MapResults = ({
   };
 
   const hideProject = () => {
-    setActiveProject(undefined);
+    setActiveProject(null);
   };
 
   const getMarkerColor = (state?: StateOfSale) => {

--- a/src/modules/search/utils/sortApartments.ts
+++ b/src/modules/search/utils/sortApartments.ts
@@ -1,18 +1,16 @@
 import React from 'react';
+import useSessionStorageState from '../../../hooks/useSessionStorageState';
 
-type SortProps = {
-  key: string;
-  direction: string;
-  alphaNumeric: boolean;
-};
-
-const SortApartments = (items: any) => {
+const SortApartments = (items: any, sessionStorageID: string) => {
   const sortDefaultProps = {
     key: 'apartment_number',
     direction: 'ascending',
     alphaNumeric: true,
   };
-  const [sortConfig, setSortConfig] = React.useState<SortProps | null>(sortDefaultProps);
+  const [sortConfig, setSortConfig] = useSessionStorageState({
+    defaultValue: sortDefaultProps,
+    key: `sortConfig-${sessionStorageID}`,
+  });
 
   const sortedApartments = React.useMemo(() => {
     let sortableApartments = [...items];


### PR DESCRIPTION
### Add custom session storage state hook

This hook is used to store state values to session storage so that it is possible to save component states when reloading the page or navigating back from the browser history

Change the default React useState to the custom useSessionStorageState for some of the components where we want to save the current state