### PR TITLE
Hide apartment number A0

### DIFF
--- a/src/hooks/useSearchResults.ts
+++ b/src/hooks/useSearchResults.ts
@@ -2,10 +2,16 @@ import { QueryParams } from '../types/common';
 import axios from 'axios';
 import { useQuery } from 'react-query';
 import mapSearchResults from '../modules/search/utils/mapSearchResults';
+import filterApartmentA0 from '../modules/search/utils/filterApartmentA0';
 
 const searchPath = process.env.REACT_APP_ELASTICSEARCH_PATH || 'elasticsearch';
 
-const useSearchResults = (query: { query?: QueryParams }, queryHeaders: { token?: string }, currentLang: string) => {
+const useSearchResults = (
+  query: { query?: QueryParams },
+  queryHeaders: { token?: string },
+  currentLang: string,
+  keepA0 = false
+) => {
   const fetchProjects = async () => {
     // Wait for token before trying to fetch data
     if (!queryHeaders.token) {
@@ -23,7 +29,12 @@ const useSearchResults = (query: { query?: QueryParams }, queryHeaders: { token?
 
     const dataAsArray: any = Object.values(data);
 
-    return dataAsArray?.map(mapSearchResults) || [];
+    const mappedSearchResults = dataAsArray?.map(mapSearchResults) || [];
+    if (keepA0) {
+      return mappedSearchResults;
+    } else {
+      return filterApartmentA0(mappedSearchResults);
+    }
   };
 
   // Fetch when query or queryHeaders update

--- a/src/modules/search/SearchContainer.tsx
+++ b/src/modules/search/SearchContainer.tsx
@@ -49,14 +49,14 @@ const SearchContainer = () => {
   const queryHeaders = { token: config?.token };
 
   // Fetch results with current search query
-  const { data: searchResults, isFetching: isSearchQueryFetching, isError: isSearchQueryError } = useSearchResults(
-    query,
-    queryHeaders,
-    currentLang
-  );
+  const {
+    data: searchResults,
+    isFetching: isSearchQueryFetching,
+    isError: isSearchQueryError,
+  } = useSearchResults(query, queryHeaders, currentLang);
 
   // Filter HITAS/HASO apartments by selected ownership type
-  const filteredSearchResults = filterProjectsByOwnershipType(searchResults, projectOwnershipType);
+  const filteredSearchResults = filterProjectsByOwnershipType(searchResults ?? [], projectOwnershipType);
 
   // Set READY, FOR_SALE, PRE_MARKETING and UPCOMING apartments from HITAS/HASO filtered lists
   const {

--- a/src/modules/search/utils/filterApartmentA0.test.ts
+++ b/src/modules/search/utils/filterApartmentA0.test.ts
@@ -1,0 +1,52 @@
+import filterApartmentA0 from './filterApartmentA0';
+
+const mockData = [
+  {
+    street_address: 'Pärinätie 13',
+    uuid: '9f79116b-898c-4fa0-80ba-c3870c624372',
+    apartments: [
+      {
+        apartment_address: 'Pärinätie 13 A0',
+        apartment_number: 'A0',
+        uuid: 'c3145a4e-ef7d-40c5-ad93-f0a164b2704a',
+      },
+      {
+        apartment_address: 'Pärinätie 13 A1',
+        apartment_number: 'A1',
+        uuid: 'c3145a4e-ef7d-40c5-ad93-f0a164b2704a',
+      },
+      {
+        apartment_address: 'Pärinätie 30 A2',
+        apartment_number: 'A2',
+        uuid: 'c3145a4e-ef7d-40c5-ad93-f0a164b2704b',
+      },
+    ],
+  },
+];
+
+const targetData = [
+  {
+    street_address: 'Pärinätie 13',
+    uuid: '9f79116b-898c-4fa0-80ba-c3870c624372',
+    apartments: [
+      {
+        apartment_address: 'Pärinätie 13 A1',
+        apartment_number: 'A1',
+        uuid: 'c3145a4e-ef7d-40c5-ad93-f0a164b2704a',
+      },
+      {
+        apartment_address: 'Pärinätie 30 A2',
+        apartment_number: 'A2',
+        uuid: 'c3145a4e-ef7d-40c5-ad93-f0a164b2704b',
+      },
+    ],
+  },
+];
+
+describe('filterApartmentA0', () => {
+  it('filters A0 apartment', () => {
+    const filteredData = filterApartmentA0(mockData);
+
+    expect(filteredData).toMatchObject(targetData);
+  });
+});

--- a/src/modules/search/utils/filterApartmentA0.ts
+++ b/src/modules/search/utils/filterApartmentA0.ts
@@ -1,0 +1,12 @@
+import type { Project } from '../../../types/common';
+
+const filterApartmentA0 = (results: Project[]) => {
+  results = results.slice();
+  for (const result of results) {
+    const apartments = result.apartments.slice();
+    result.apartments = apartments.filter((apartment) => apartment.apartment_number?.toUpperCase() !== 'A0');
+  }
+  return results;
+};
+
+export default filterApartmentA0;


### PR DESCRIPTION
I decided to put the filtering as high up as possible to `useSearchResults` . Default behaviour is to filter A0 apartment. The option to overirde the default behaviour is there but I guess it's a bit unnecessary. 