### PR TITLE
Implement RESERVED_HASO state for apartments

### DIFF
--- a/src/modules/search/components/result/ApplicationStatus.test.tsx
+++ b/src/modules/search/components/result/ApplicationStatus.test.tsx
@@ -23,6 +23,11 @@ test('renders ApplicationStatus as Reserved', () => {
   expect(screen.getByText('SEARCH:apartment-reserved')).toBeDefined();
 });
 
+test('renders ApplicationStatus as Reserved', () => {
+  render(<ApplicationStatus status="RESERVED_HASO" />);
+  expect(screen.getByText('SEARCH:apartment-reserved')).toBeDefined();
+});
+
 test('renders ApplicationStatus as Sold', () => {
   render(<ApplicationStatus status="SOLD" />);
   expect(screen.getByText('SEARCH:apartment-sold')).toBeDefined();

--- a/src/modules/search/components/result/ApplicationStatus.tsx
+++ b/src/modules/search/components/result/ApplicationStatus.tsx
@@ -21,6 +21,7 @@ const RenderAvailabilityInfo = ({ status, dotOnly = false }: Props) => {
           <span className={dotOnly ? 'sr-only' : ''}>{t('SEARCH:apartment-free')}</span>
         </>
       );
+    case ApplicationStatus.ReservedHaso:
     case ApplicationStatus.Reserved:
       return (
         <>

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -200,6 +200,7 @@ export enum StateOfSale {
 export enum ApplicationStatus {
   Vacant = 'VACANT',
   Reserved = 'RESERVED',
+  ReservedHaso = 'RESERVED_HASO',
   Sold = 'SOLD',
   Low = 'LOW',
   Medium = 'MEDIUM',


### PR DESCRIPTION
Added RESERVED_HASO state to address a specific issue where the RESERVED_HASO status was incorrectly displayed due to its omission. Adding it will now make sure the correct Reserved status is displayed.