### PR TITLE
Change right_of_occupancy_payment logic

### DIFF
--- a/src/modules/search/components/result/list/ApartmentTable.tsx
+++ b/src/modules/search/components/result/list/ApartmentTable.tsx
@@ -198,13 +198,11 @@ const ApartmentTable = ({
             {projectOwnershipIsHaso ? (
               <button
                 type="button"
-                onClick={() => setSort('right_of_occupancy_payment', false)}
+                onClick={() => setSort('haso_fee', false)}
                 className={apartmentSortClasses('right_of_occupancy_payment')}
               >
                 <span className="sr-only">
-                  {isCurrentlyActiveSort('right_of_occupancy_payment')
-                    ? t('SEARCH:aria-is-active-sort')
-                    : t('SEARCH:aria-set-sort')}
+                  {isCurrentlyActiveSort('haso_fee') ? t('SEARCH:aria-is-active-sort') : t('SEARCH:aria-set-sort')}
                   ,&nbsp;
                 </span>
                 <span>{t('SEARCH:right-of-occupancy-payment')}</span>

--- a/src/modules/search/utils/getApartmentPrice.test.ts
+++ b/src/modules/search/utils/getApartmentPrice.test.ts
@@ -1,10 +1,9 @@
 import { getApartmentPrice } from './getApartmentPrice';
 
 describe('getApartmentPrice', () => {
-  it("should return '-' if is haso and both release_payment and right_of_occupancy_payment is null", () => {
+  it("should return '-' if is haso and both release_payment is null", () => {
     const apartment = {
       debt_free_sales_price: null,
-      right_of_occupancy_payment: null,
       release_payment: null,
       project_ownership_type: 'haso',
     };
@@ -13,25 +12,25 @@ describe('getApartmentPrice', () => {
 
   it('should return release_payment if is haso and release_payment exists and is > 0', () => {
     const apartment = {
-      right_of_occupancy_payment: 0,
+      haso_fee: 0,
       release_payment: 10000000,
       project_ownership_type: 'haso',
     };
     expect(getApartmentPrice(apartment)).toEqual('100\xa0000 \u20AC');
   });
 
-  it('should return right_of_occupancy_payment if is haso and release_payment exists and is <= 0', () => {
+  it('should return haso_fee if is haso and release_payment exists and is <= 0', () => {
     const apartment = {
-      right_of_occupancy_payment: 10000000,
+      haso_fee: 10000000,
       release_payment: 0,
       project_ownership_type: 'haso',
     };
     expect(getApartmentPrice(apartment)).toEqual('100\xa0000 \u20AC');
   });
 
-  it('should return right_of_occupancy_payment if is haso and release_payment does not exist', () => {
+  it('should return haso_fee if is haso and release_payment does not exist', () => {
     const apartment = {
-      right_of_occupancy_payment: 10000000,
+      haso_fee: 10000000,
       release_payment: null,
       project_ownership_type: 'haso',
     };

--- a/src/modules/search/utils/getApartmentPrice.ts
+++ b/src/modules/search/utils/getApartmentPrice.ts
@@ -4,14 +4,14 @@ import formattedPrice from './formatPrice';
 export const getApartmentPrice = (apartment: Apartment): string => {
   if (!apartment) return '-';
 
-  const { debt_free_sales_price, right_of_occupancy_payment, release_payment, project_ownership_type } = apartment;
+  const { haso_fee, debt_free_sales_price, release_payment, project_ownership_type } = apartment;
 
   if (project_ownership_type.toLowerCase() === 'haso') {
     if (release_payment && release_payment > 0) {
       return formattedPrice(release_payment);
     }
-    if (right_of_occupancy_payment) {
-      return formattedPrice(right_of_occupancy_payment);
+    if (haso_fee && haso_fee > 0) {
+      return formattedPrice(haso_fee);
     }
     return '-';
   }

--- a/src/modules/search/utils/sortApartments.ts
+++ b/src/modules/search/utils/sortApartments.ts
@@ -11,7 +11,6 @@ const SortApartments = (items: any, sessionStorageID: string) => {
     defaultValue: sortDefaultProps,
     key: `sortConfig-${sessionStorageID}`,
   });
-
   const sortedApartments = React.useMemo(() => {
     let sortableApartments = [...items];
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -18,6 +18,7 @@ export type Apartment = {
   has_balcony: boolean;
   has_terrace: boolean;
   has_yard: boolean;
+  haso_fee: number;
   housing_company_fee: number;
   kitchen_appliances: string;
   living_area: number;
@@ -79,7 +80,6 @@ export type Apartment = {
   project_virtual_presentation_url: string;
   project_zoning_info: string;
   project_zoning_status: string;
-  right_of_occupancy_payment: number;
   release_payment: number;
   room_count: number;
   sales_price: number;


### PR DESCRIPTION
If release_payment exists use it as price, if not use haso_fee. The right_of_occupancy_payment is no longer used in the Apartment object. Removed right_of_occupancy_payment from Apartment, added haso_fee.