### PR TITLE
hotfix 2026 06 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "asuntomyynti-react",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "asuntomyynti-react",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "dependencies": {
         "@sentry/react": "^10.39.0",
         "@tanstack/react-query": "^5.90.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "asuntomyynti-react",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/modules/search/utils/formatPrice.ts
+++ b/src/modules/search/utils/formatPrice.ts
@@ -1,5 +1,5 @@
 export const formattedPrice = (value: number) => {
-  const calculatedPrice = value / 100;
+  const calculatedPrice = value;
   return `${calculatedPrice.toLocaleString('fi-FI')} \u20AC`;
 };
 


### PR DESCRIPTION
- **Temporarily handle monetary values as euros instead of cents due to unexpected discrepancy between test and prod envs**
- **Bump version to 1.6.4**
